### PR TITLE
Support NatNet v4.1

### DIFF
--- a/natnet_client/data_descriptions.py
+++ b/natnet_client/data_descriptions.py
@@ -241,6 +241,8 @@ class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
         dataset_count = buffer.read_uint32()
         for i in range(0, dataset_count):
             data_type = buffer.read_uint32()
+            if protocol_version >= Version(4, 1):
+                _dataset_size = buffer.read_uint32()
             if data_type in data_desc_types:
                 name, desc_type = data_desc_types[data_type]
                 unpacked_data = desc_type.read_from_buffer(buffer, protocol_version)
@@ -248,4 +250,5 @@ class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
             else:
                 print(f"Type: {data_type} unknown. Stopped processing at {buffer.pointer}/{len(buffer.data)} bytes "
                       f"({i + 1}/{dataset_count}) datasets.")
+                break
         return DataDescriptions(**data_dict)

--- a/natnet_client/data_descriptions.py
+++ b/natnet_client/data_descriptions.py
@@ -250,5 +250,4 @@ class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
             else:
                 print(f"Type: {data_type} unknown. Stopped processing at {buffer.pointer}/{len(buffer.data)} bytes "
                       f"({i + 1}/{dataset_count}) datasets.")
-                break
         return DataDescriptions(**data_dict)

--- a/natnet_client/data_descriptions.py
+++ b/natnet_client/data_descriptions.py
@@ -166,13 +166,64 @@ class CameraDescription(PacketComponent, NamedTuple(
         return CameraDescription(name, position, orientation)
 
 
+class MarkerDescription(PacketComponent, NamedTuple(
+    "MarkerDescriptionFields",
+    (("name", str),
+     ("marker_id", int),
+     ("position", Vec3),
+     ("marker_size", float),
+     ("marker_params", int)))):
+
+    @classmethod
+    def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "MarkerDescription":
+        name = buffer.read_string()
+        marker_id = buffer.read_uint32()
+        position = buffer.read_float32_array(3)
+        marker_size = buffer.read_float32()
+        marker_params = buffer.read_uint16()
+        
+        return MarkerDescription(name, marker_id, position, marker_size, marker_params)
+
+
+class AssetDescription(PacketComponent, NamedTuple(
+    "AssetDescriptionFields",
+    (("name", str),
+     ("asset_type", int),
+     ("asset_id", int),
+     ("rigid_body_descriptions", Tuple[RigidBodyDescription, ...]),
+     ("marker_descriptions", Tuple[MarkerDescription, ...])))):
+
+    @classmethod
+    def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "AssetDescription":
+        name = buffer.read_string()
+        asset_type = buffer.read_uint32()
+        asset_id = buffer.read_uint32()
+
+        num_rbs = buffer.read_uint32()
+        rigid_body_descriptions = [
+            RigidBodyDescription.read_from_buffer(buffer, protocol_version)
+            for _ in range(num_rbs)
+        ]
+
+        num_markers = buffer.read_uint32()
+        marker_descriptions = [
+            MarkerDescription.read_from_buffer(buffer, protocol_version)
+            for _ in range(num_markers)
+        ]
+
+        return AssetDescription(name, asset_type, asset_id, 
+                               tuple(rigid_body_descriptions), 
+                               tuple(marker_descriptions))
+
+
 class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
         ("marker_sets", Tuple[MarkerSetDescription, ...]),
         ("rigid_bodies", Tuple[RigidBodyDescription, ...]),
         ("skeletons", Tuple[SkeletonDescription, ...]),
         ("force_plates", Tuple[ForcePlateDescription, ...]),
         ("devices", Tuple[DeviceDescription, ...]),
-        ("cameras", Tuple[CameraDescription, ...])))):
+        ("cameras", Tuple[CameraDescription, ...]),
+        ("assets", Tuple[AssetDescription, ...])))):
 
     @classmethod
     def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "DataDescriptions":
@@ -182,7 +233,8 @@ class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
             2: ("skeletons", SkeletonDescription),
             3: ("force_plates", ForcePlateDescription),
             4: ("devices", DeviceDescription),
-            5: ("cameras", CameraDescription)
+            5: ("cameras", CameraDescription),
+            6: ("assets", AssetDescription),
         }
         data_dict = {n: [] for i, (n, f) in data_desc_types.items()}
         # # of data sets to process

--- a/natnet_client/data_frame.py
+++ b/natnet_client/data_frame.py
@@ -96,6 +96,53 @@ class Skeleton(PacketComponent):
 
 
 @dataclass(frozen=True)
+class AssetMarkerData(PacketComponent):
+    marker_id: int
+    pos: Vec3
+    marker_size: float
+    marker_params: int
+    residual: float
+
+    @classmethod
+    def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "Asset":
+        return AssetMarkerData(buffer.read_uint32(), buffer.read_float32_array(3), buffer.read_float32(),
+                               buffer.read_uint16(), buffer.read_float32())
+
+
+@dataclass(frozen=True)
+class AssetRigidBodyData(PacketComponent):
+    id_num: int
+    pos: Vec3
+    rot: Vec4
+    mean_error: float
+    param: int
+
+    @classmethod
+    def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "Asset":
+        return AssetRigidBodyData(buffer.read_uint32(), buffer.read_float32_array(3), buffer.read_float32_array(4),
+                                  buffer.read_float32(), buffer.read_uint16())
+
+
+@dataclass(frozen=True)
+class Asset(PacketComponent):
+    asset_id: int
+    rigid_bodies: Tuple[AssetRigidBodyData, ...]
+    markers: Tuple[AssetMarkerData, ...]
+
+    @classmethod
+    def read_from_buffer(cls, buffer: PacketBuffer, protocol_version: Version) -> "Asset":
+        asset_id = buffer.read_uint32()
+
+        num_rbs = buffer.read_uint32()
+        rigid_bodies = [AssetRigidBodyData.read_from_buffer(buffer, protocol_version) for _ in range(num_rbs)]
+
+        num_markers = buffer.read_uint32()
+        markers = [AssetMarkerData.read_from_buffer(buffer, protocol_version) for _ in range(num_markers)]
+
+        return Asset(asset_id, tuple(rigid_bodies), tuple(markers))
+
+
+@dataclass(frozen=True)
 class LabeledMarker(PacketComponent):
     id_num: int
     pos: Vec3
@@ -230,6 +277,7 @@ class DataFrame(PacketComponent):
     unlabeled_marker_pos: Tuple[Vec3, ...]
     rigid_bodies: Tuple[RigidBody, ...]
     skeletons: Tuple[Skeleton, ...]
+    assets: Tuple[Asset, ...]
     labeled_markers: Tuple[LabeledMarker, ...]
     force_plates: Tuple[ForcePlate, ...]
     devices: Tuple[Device, ...]
@@ -241,6 +289,7 @@ class DataFrame(PacketComponent):
         "unlabeled_marker_pos": Version(0),
         "rigid_bodies": Version(0),
         "skeletons": Version(2, 1),
+        "assets": Version(4, 1),
         "labeled_markers": Version(2, 3),
         "force_plates": Version(2, 9),
         "devices": Version(2, 11),

--- a/natnet_client/data_frame.py
+++ b/natnet_client/data_frame.py
@@ -308,6 +308,8 @@ class DataFrame(PacketComponent):
                     # Type is a tuple
                     element_count = buffer.read_uint32()
                     generic_type = field.type.__args__[0]
+                    if protocol_version >= Version(4, 1):
+                        _dataset_size = buffer.read_uint32()
                     if generic_type == Vec3:
                         kwargs[field.name] = tuple(buffer.read_float32_array(3) for _ in range(element_count))
                     else:


### PR DESCRIPTION
With NatNet 4.1 two changes were introduced that require an update:

- Trained marker sets aka "Assets" were added. We add data description and frame data support for them
- A dataset size field has been added which breaks parsing of old data. We now parse this field if the version is above or equal 4.1

We tested these changes with Motive 3.1.4, using both streams without and with assets.