### PR TITLE
Throw an exception on unknown data description types

### DIFF
--- a/natnet_client/__init__.py
+++ b/natnet_client/__init__.py
@@ -1,6 +1,7 @@
 from .data_descriptions import *
 from .data_frame import *
 from .event import Event
+from .exceptions import NatNetError, NatNetNetworkError, NatNetProtocolError
 from .nat_net_client import NatNetClient
 from .server_info import *
 from .version import *

--- a/natnet_client/data_descriptions.py
+++ b/natnet_client/data_descriptions.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple, Tuple, Optional
 
 from .data_types import Vec3, Vec4
+from .exceptions import NatNetProtocolError
 from .packet_buffer import PacketBuffer
 from .packet_component import PacketComponent, PacketComponentArray
 from .version import Version
@@ -194,6 +195,7 @@ class DataDescriptions(PacketComponent, NamedTuple("DataDescriptions", (
                 unpacked_data = desc_type.read_from_buffer(buffer, protocol_version)
                 data_dict[name].append(unpacked_data)
             else:
-                print(f"Type: {data_type} unknown. Stopped processing at {buffer.pointer}/{len(buffer.data)} bytes "
-                      f"({i + 1}/{dataset_count}) datasets.")
+                raise NatNetProtocolError(f"Unknown data type {data_type} encountered while parsing data descriptions. "
+                                        f"Stopped processing at {buffer.pointer}/{len(buffer.data)} bytes, "
+                                        f"({i + 1}/{dataset_count}) datasets.")
         return DataDescriptions(**data_dict)

--- a/natnet_client/exceptions.py
+++ b/natnet_client/exceptions.py
@@ -1,0 +1,17 @@
+import socket
+
+
+class NatNetError(Exception):
+    pass
+
+
+class NatNetNetworkError(NatNetError):
+    def __init__(self, socket_name: str, multicast: bool, inner_error: socket.error):
+        super().__init__(
+            f"{socket_name} socket error occurred:\n{inner_error}\nCheck Motive/Server mode requested mode agreement "
+            f"(you requested {'multi' if multicast else 'uni'}cast).")
+        self.inner_error = inner_error
+
+
+class NatNetProtocolError(NatNetError):
+    pass

--- a/natnet_client/nat_net_client.py
+++ b/natnet_client/nat_net_client.py
@@ -5,26 +5,11 @@ from typing import Optional
 
 from .data_frame import DataFrame
 from .event import Event
+from .exceptions import NatNetError, NatNetNetworkError, NatNetProtocolError
 from .server_info import ServerInfo
 from .data_descriptions import DataDescriptions
 from .packet_buffer import PacketBuffer
 from .version import Version
-
-
-class NatNetError(Exception):
-    pass
-
-
-class NatNetNetworkError(NatNetError):
-    def __init__(self, socket_name: str, multicast: bool, inner_error: socket.error):
-        super().__init__(
-            f"{socket_name} socket error occurred:\n{inner_error}\nCheck Motive/Server mode requested mode agreement "
-            f"(you requested {'multi' if multicast else 'uni'}cast).")
-        self.inner_error = inner_error
-
-
-class NatNetProtocolError(NatNetError):
-    pass
 
 
 class NatNetClient:


### PR DESCRIPTION
Instead of just printing a message and then ignoring an unknown data description type, we "fail hard" by throwing an exception. To this end, we factor out the existing exceptions into their own file.