### PR TITLE
Fix: Handle UnicodeDecodeError and suppress exceptions for Motive 3 compatibility

### DIFF
--- a/natnet/nat_net_client.py
+++ b/natnet/nat_net_client.py
@@ -141,7 +141,10 @@ class NatNetClient:
         try:
             data, addr = in_socket.recvfrom(recv_buffer_size)
             if len(data) > 0:
-                self.__process_message(PacketBuffer(data))
+                try:
+                    self.__process_message(PacketBuffer(data))
+                except Exception as e:
+                    print(f"Warning: Failed to process packet: {e}")
                 return True
         except (BlockingIOError, socket.timeout):
             pass

--- a/natnet/packet_buffer.py
+++ b/natnet/packet_buffer.py
@@ -21,7 +21,7 @@ class PacketBuffer:
         else:
             data_slice = self.__data[self.pointer : self.pointer + max_length]
         str_enc, separator, remainder = bytes(data_slice).partition(b"\0")
-        str_dec = str_enc.decode("utf-8")
+        str_dec = str_enc.decode("utf-8", errors="replace")
         if static_length:
             assert max_length is not None
             self.pointer += max_length


### PR DESCRIPTION
# NatNet 0.2.0 Compatibility Patch for Motive 3.X (NatNet 4.2)

## Problem Description
The `natnet` python library (v0.2.0) crashes when connecting to newer Motive servers (e.g., Motive 3.3.0 which uses NatNet Protocol 4.2).

The crashes occur in two places:
1.  **UnicodeDecodeError**: When parsing strings in `MODELDEF` packets using `PacketBuffer.read_string`. The newer protocol seems to send bytes that are not strictly valid utf-8 in the expected context or the parsing offset is misaligned.
2.  **struct.error**: When parsing `DataDescriptions`. Because the library does not support Protocol 4.X, it fails to account for new fields or size changes in the packet structure, leading to invalid pointer offsets.

## Proposed Fix

1.  **Robust String Decoding**: Patches `PacketBuffer.read_string` to use `errors="replace"` when decoding utf-8. This prevents the immediate crash on invalid strings.
2.  **Exception Swallowing in Message Processing**: Patches `NatNetClient.__process_message` to catch and log exceptions instead of letting them propagate and kill the client thread.
    -   *Rationale*: Since the `MODELDEF` packet parsing is fundamentally incompatible, we simply want to ignore it (or partial failures) so that the client can continue to process `FRAMEOFDATA` packets, which **are** backward compatible enough to extract rigid body poses.
